### PR TITLE
Add docker and react skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_NAME=plataforma
+DB_USER=postgres
+DB_PASSWORD=postgres
+JWT_SECRET=changeme
+OPENAI_API_KEY=your_openai_key
+SPRING_MAIL_USERNAME=mail@example.com
+SPRING_MAIL_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/plataforma-educacional-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -96,3 +96,17 @@ Para uma descrição detalhada das tabelas, colunas e relacionamentos, consulte 
 ---
 
 Este README fornece uma visão geral e instruções básicas. Para detalhes específicos sobre a implementação, consulte o código-fonte e os comentários nas classes relevantes.
+
+## 8. Docker e Frontend
+
+Um diretório `frontend/` com um esqueleto de aplicação React foi incluído neste repositório. O backend e o frontend possuem `Dockerfile` dedicados e um `docker-compose.yml` simplifica a execução de ambos os serviços juntamente com o banco PostgreSQL.
+
+Para iniciar tudo com Docker, copie o arquivo `.env.example` para `.env` e execute:
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+O frontend estará disponível em `http://localhost:3000` e o backend em `http://localhost:8080`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "5432:5432"
+  backend:
+    build: .
+    environment:
+      DB_HOST: db
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+  frontend:
+    build: ./frontend
+    environment:
+      REACT_APP_API_URL: http://localhost:8080
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production --silent || true
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npx", "serve", "-s", "build"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "plataforma-educacional-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
+    "@mui/material": "^5.15.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Plataforma Educacional</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Login from './pages/Login';
+
+function App() {
+  return <Login />;
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Button, Container, TextField, Typography } from '@mui/material';
+
+function Login() {
+  return (
+    <Container maxWidth="sm" style={{ marginTop: '4rem' }}>
+      <Typography variant="h4" gutterBottom>Login</Typography>
+      <form>
+        <TextField label="Email" fullWidth margin="normal" />
+        <TextField label="Senha" type="password" fullWidth margin="normal" />
+        <Button variant="contained" color="primary" fullWidth>Entrar</Button>
+      </form>
+    </Container>
+  );
+}
+
+export default Login;


### PR DESCRIPTION
## Summary
- add example environment configuration
- provide Dockerfile for backend and Dockerfile for new React frontend
- create docker-compose to run database, backend and frontend
- basic React login page as a starting point
- mention Docker and frontend in the README

## Testing
- `./mvnw test` *(fails: failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_68448b61c5a88333838e94016ad2d351