### PR TITLE
Fix JWT parser usage

### DIFF
--- a/src/main/java/br/com/plataformaeducacional/security/JwtTokenUtil.java
+++ b/src/main/java/br/com/plataformaeducacional/security/JwtTokenUtil.java
@@ -35,9 +35,8 @@ public class JwtTokenUtil {
     }
 
     public String getUsernameFromToken(String token) {
-        return Jwts.parserBuilder()
+        return Jwts.parser()
                 .setSigningKey(getSigningKey())
-                .build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
@@ -45,7 +44,7 @@ public class JwtTokenUtil {
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parse(token);
+            Jwts.parser().setSigningKey(getSigningKey()).parse(token);
             return true;
         } catch (JwtException | IllegalArgumentException ex) {
             return false;


### PR DESCRIPTION
## Summary
- update `JwtTokenUtil` to use `Jwts.parser()` instead of `parserBuilder`

## Testing
- `./mvnw test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68448dd14804833385c7565636f5b962