### PR TITLE
Fix JWT parser usage

### DIFF
--- a/src/main/java/br/com/plataformaeducacional/security/JwtTokenUtil.java
+++ b/src/main/java/br/com/plataformaeducacional/security/JwtTokenUtil.java
@@ -35,8 +35,9 @@ public class JwtTokenUtil {
     }
 
     public String getUsernameFromToken(String token) {
-        return Jwts.parser()
+        return Jwts.parserBuilder()
                 .setSigningKey(getSigningKey())
+                .build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
@@ -44,7 +45,7 @@ public class JwtTokenUtil {
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parser().setSigningKey(getSigningKey()).parse(token);
+            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parse(token);
             return true;
         } catch (JwtException | IllegalArgumentException ex) {
             return false;


### PR DESCRIPTION
## Summary
- fix parsing calls in `JwtTokenUtil` for modern jjwt library

## Testing
- `./mvnw -q -DskipTests install` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68448e7f076883338b33beb8f9e8d6b9