### PR TITLE
Fix Maven wrapper config and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Este projeto implementa uma plataforma web educacional utilizando Spring Boot e 
 Para construir e executar este projeto localmente, você precisará de:
 
 *   **Java Development Kit (JDK) 17 ou superior:** Certifique-se de que a variável de ambiente `JAVA_HOME` esteja configurada corretamente.
-*   **Apache Maven:** Utilizado para gerenciamento de dependências e build do projeto. O projeto inclui o Maven Wrapper (`mvnw`), que pode baixar o Maven automaticamente se necessário.
+*   **Apache Maven:** Utilizado para gerenciamento de dependências e build do projeto. O projeto inclui o Maven Wrapper (`mvnw`), que pode baixar o Maven automaticamente se necessário. Em ambientes sem acesso à internet, é necessário ter o Maven previamente instalado para que o build seja executado.
 *   **PostgreSQL:** Banco de dados relacional utilizado para persistência. Crie um banco de dados (ex: `plataforma_educacional`).
 
 ## 3. Configuração

--- a/backend/.mvn/wrapper/maven-wrapper.properties
+++ b/backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip


### PR DESCRIPTION
## Summary
- copy Maven wrapper properties into `backend` so `mvnw` can locate them
- document that Maven must be installed when running without internet access

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68462d2c845c8333ba52a45208acf5aa